### PR TITLE
Add SolarCalculatorHQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Short description.
 - [Greenwashing Checker](https://greenwashing-checker.com) - Tool to detect greenwashing in corporate sustainability claims.
 - [Mattermore.io](https://www.mattermore.io/) - Newsletter highlighting companies using AI & data science to reverse climate change; useful for discovering new initiatives/work opportunities, delivered every week.
 - [Norrsken Foundation](https://www.norrsken.org/) - Swedish foundation which supports and invests in organizations that have a positive impact on society.
+- [SolarCalculatorHQ](https://solarcalculatorhq.com) - Free multi-locale solar PV calculator suite (system sizing, payback period, ROI, off-grid load) with per-region cost data and code references for 10 markets.
 
 ## Research
 


### PR DESCRIPTION
## Adding

**[SolarCalculatorHQ](https://solarcalculatorhq.com)** - Free multi-locale solar PV calculator suite (system sizing, payback period, ROI, off-grid load) with per-region cost data and code references for 10 markets.

Placed at the end of the **More Resources** section.

## Why it fits

The More Resources section already lists hosted, single-purpose web tools — Carbon Badge (carbon footprint calculator), DPP Tool (Digital Product Passport generator), and Greenwashing Checker. SolarCalculatorHQ is in the same vein: a free no-signup hosted calculator suite focused on residential clean-energy decisions.

What makes it differentiated:

- 10-locale coverage (US, UK, AU, CA, DE, FR, ES, BR, IT, NL) with per-region currency, units, electrical code references (NEC, BS 7671, AS/NZS 3000, VDE, REBT, etc.) and authority sources cited (NREL, MCS, Clean Energy Council, Bundesnetzagentur, IDAE, and others).
- Calculator math derived from first principles and documented per-page.
- Underlying cost/irradiance data published under CC-BY 4.0 at /data/ — open license, free to remix.

No paywall, no signup, no email capture.

## Maintenance

Site is actively maintained and continues to add calculators across all 10 locales.